### PR TITLE
Action packer re-use

### DIFF
--- a/as-packages/chain/assembly/helpers.ts
+++ b/as-packages/chain/assembly/helpers.ts
@@ -1,6 +1,6 @@
 import { PermissionLevel, Action } from "./action"
-import { MultiIndexValue } from "./mi"
 import { Name } from "./name"
+import { Packer } from "./serializer"
 
 export class ActionWrapperAct {
     constructor(
@@ -9,7 +9,7 @@ export class ActionWrapperAct {
         public permissionLevel: PermissionLevel
     ){}
 
-    send <T extends MultiIndexValue>(data: T): void {
+    send <T extends Packer>(data: T): void {
         const permissions = [this.permissionLevel]
         const action = new Action(permissions, this.contract, this.action, data.pack())
         action.send()

--- a/examples/eosio.token/tables.ts
+++ b/examples/eosio.token/tables.ts
@@ -2,11 +2,9 @@ import { Asset, Name, table, primary } from "as-chain";
 
 @table("accounts")
 export class account {
-    balance: Asset;
-
-    constructor (balance: Asset = new Asset()) {
-        this.balance = balance;
-    }
+    constructor (
+        public balance: Asset = new Asset()
+    ){}
 
     @primary
     get primary(): u64 {
@@ -16,19 +14,11 @@ export class account {
 
 @table("stat")
 export class currency_stats {
-    supply: Asset;
-    max_supply: Asset;
-    issuer: Name;
-
     constructor (
-       supply: Asset = new Asset(),
-       max_supply: Asset =  new Asset(),
-       issuer: Name = new Name(),
-    ) {
-        this.supply = supply;
-        this.max_supply = max_supply;
-        this.issuer = issuer;
-    }
+       public supply: Asset = new Asset(),
+       public max_supply: Asset =  new Asset(),
+       public issuer: Name = new Name(),
+    ) {}
 
     @primary
     get primary(): u64 {

--- a/examples/inlineaction/inlineaction.ts
+++ b/examples/inlineaction/inlineaction.ts
@@ -1,25 +1,19 @@
-import { Contract, PermissionLevel, printString, action, contract, packer, ActionWrapper } from "as-chain"
-
-@packer
-class MyData {
-    constructor(
-        public name: string
-    ){}
-}
+import { Contract, PermissionLevel, printString, action, contract, ActionWrapper } from "as-chain"
 
 @contract("inlineaction")
 class InlineAction extends Contract {
+    static sayGoodbyeAction: ActionWrapper = new ActionWrapper("saygoodbye");
+    static sayHelloAction: ActionWrapper = new ActionWrapper("sayhello");
+    
     @action("saygoodbye")
-    sayGoodbye(name: string): void {
-        printString(`+++goodbye, ${name}\n`)    
+    sayGoodbye(name: string, name2: string): void {
+        printString(`+++goodbye, ${name} ${name2}\n`)    
     }
     
     @action("sayhello")
     sayHello(name: string): void {
-        const actionData = new MyData('alice');
-        const actionWrapper = new ActionWrapper("saygoodbye")
-        const action = actionWrapper.act(this.receiver, new PermissionLevel(this.receiver))
-        action.send(actionData)
+        const action = InlineAction.sayGoodbyeAction.act(this.receiver, new PermissionLevel(this.receiver))
+        action.send(new sayGoodbyeAction('alice', 'bob'))
         printString(`hello, ${name}\n`)
     }
 }

--- a/examples/inlineaction/inlineaction.ts
+++ b/examples/inlineaction/inlineaction.ts
@@ -1,4 +1,4 @@
-import { Contract, PermissionLevel, printString, action, contract, ActionWrapper } from "as-chain"
+import { Contract, PermissionLevel, printString, action, contract, ActionWrapper, Asset, Symbol, packer } from "as-chain"
 
 @contract("inlineaction")
 class InlineAction extends Contract {
@@ -6,14 +6,15 @@ class InlineAction extends Contract {
     static sayHelloAction: ActionWrapper = new ActionWrapper("sayhello");
     
     @action("saygoodbye")
-    sayGoodbye(name: string, name2: string): void {
-        printString(`+++goodbye, ${name} ${name2}\n`)    
+    sayGoodbye(name: string, asset: Asset, num: u64): void {
+        printString(`+++goodbye, ${name} ${asset} ${num}\n`)    
     }
     
     @action("sayhello")
     sayHello(name: string): void {
         const action = InlineAction.sayGoodbyeAction.act(this.receiver, new PermissionLevel(this.receiver))
-        action.send(new sayGoodbyeAction('alice', 'bob'))
+        const actionParams = new sayGoodbyeAction('alice', new Asset(0, new Symbol("EOS", 4)), 4)
+        action.send(actionParams)
         printString(`hello, ${name}\n`)
     }
 }

--- a/ts-packages/transform/src/preprocess/handlebars.ts
+++ b/ts-packages/transform/src/preprocess/handlebars.ts
@@ -34,14 +34,14 @@ Handlebars.registerHelper("generateActionMember", function (fn: ParameterNodeDef
     let code: string[] = [];
     let plainType = fn.type.plainTypeNode;
     if (plainType == 'string') {
-        code.push(` ${fn.name}: string = "";`);
+        code.push(`public ${fn.name}: string = "",`);
     } else if (plainType == 'string[]') {
-        code.push(` ${fn.name}: string[] = [];`);
+        code.push(`public ${fn.name}: string[] = [],`);
     } else {
         if (TypeHelper.isPrimitiveType(fn.type.typeKind)) {
-            code.push(` ${fn.name}: ${plainType};`);
+            code.push(`public ${fn.name}: ${plainType},`);
         } else {
-            code.push(` ${fn.name}!: ${plainType};`);
+            code.push(`public ${fn.name}!: ${plainType},`);
         }
     }
     return code.join(EOL);

--- a/ts-packages/transform/src/preprocess/handlebars.ts
+++ b/ts-packages/transform/src/preprocess/handlebars.ts
@@ -34,16 +34,41 @@ Handlebars.registerHelper("generateActionMember", function (fn: ParameterNodeDef
     let code: string[] = [];
     let plainType = fn.type.plainTypeNode;
     if (plainType == 'string') {
-        code.push(`public ${fn.name}: string = "",`);
+        code.push(` ${fn.name}: string = "";`);
     } else if (plainType == 'string[]') {
-        code.push(`public ${fn.name}: string[] = [],`);
+        code.push(` ${fn.name}: string[] = [];`);
     } else {
         if (TypeHelper.isPrimitiveType(fn.type.typeKind)) {
-            code.push(`public ${fn.name}: ${plainType},`);
+            code.push(` ${fn.name}: ${plainType};`);
         } else {
-            code.push(`public ${fn.name}!: ${plainType},`);
+            code.push(` ${fn.name}!: ${plainType};`);
         }
     }
+    return code.join(EOL);
+});
+
+Handlebars.registerHelper("generateActionParam", function (fn: ParameterNodeDef) {
+    let code: string[] = [];
+    let plainType = fn.type.plainTypeNode;
+
+    if (plainType == 'string') {
+        code.push(` ${fn.name}: string = "",`);
+    } else if (plainType == 'string[]') {
+        code.push(` ${fn.name}: string[] = [],`);
+    } else {
+        if (TypeHelper.isPrimitiveType(fn.type.typeKind)) {
+            code.push(` ${fn.name}: ${plainType} = 0,`);
+        } else {
+            code.push(` ${fn.name}: ${plainType} | null = null,`);
+        }
+    }
+
+    return code.join(EOL);
+});
+
+Handlebars.registerHelper("generateActionConstructor", function (fn: ParameterNodeDef) {
+    let code: string[] = [];
+    code.push(` if(${fn.name}) this.${fn.name} = ${fn.name};`);
     return code.join(EOL);
 });
 

--- a/ts-packages/transform/src/tpl/action.ts
+++ b/ts-packages/transform/src/tpl/action.ts
@@ -5,12 +5,21 @@ import { CONFIG } from "../config/compile";
 // methodName: string;
 
 export const actionTpl = `
+
 class {{methodName}}Action implements _chain.Packer {
+    {{#each parameters}}
+    {{#generateActionMember .}}{{/generateActionMember}}
+    {{/each}}
+
     constructor (
         {{#each parameters}}
-        {{#generateActionMember .}}{{/generateActionMember}}
+        {{#generateActionParam .}}{{/generateActionParam}}
         {{/each}}
-    ) {}
+    ) {
+        {{#each parameters}}
+        {{#generateActionConstructor .}}{{/generateActionConstructor}}
+        {{/each}}
+    }
 
     pack(): u8[] {
         let enc = new _chain.Encoder(this.getSize());
@@ -35,5 +44,4 @@ class {{methodName}}Action implements _chain.Packer {
         {{/each}}
         return size;
     }
-}
-`;
+}`;

--- a/ts-packages/transform/src/tpl/action.ts
+++ b/ts-packages/transform/src/tpl/action.ts
@@ -4,10 +4,13 @@ import { CONFIG } from "../config/compile";
 // parameters: ParameterNodeDef[] = [];
 // methodName: string;
 
-export const actionTpl = `class {{methodName}}Action implements _chain.Packer {
-    {{#each parameters}}
-    {{#generateActionMember .}}{{/generateActionMember}}
-    {{/each}}
+export const actionTpl = `
+class {{methodName}}Action implements _chain.Packer {
+    constructor (
+        {{#each parameters}}
+        {{#generateActionMember .}}{{/generateActionMember}}
+        {{/each}}
+    ) {}
 
     pack(): u8[] {
         let enc = new _chain.Encoder(this.getSize());

--- a/ts-packages/transform/src/tpl/main.ts
+++ b/ts-packages/transform/src/tpl/main.ts
@@ -3,6 +3,7 @@ import { CONFIG } from "../config/compile";
 // let scope = CONFIG.scope;
 
 export const mainTpl = `
+
 export function apply(receiver: u64, firstReceiver: u64, action: u64): void {
   let _receiver = new _chain.Name(receiver);
   let _firstReceiver = new _chain.Name(firstReceiver);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3461,11 +3461,6 @@ read-pkg@^5.2.0:
     parse-json "^5.0.0"
     type-fest "^0.6.0"
 
-reflect-metadata@^0.1.13:
-  version "0.1.13"
-  resolved "https://registry.yarnpkg.com/reflect-metadata/-/reflect-metadata-0.1.13.tgz#67ae3ca57c972a2aa1642b10fe363fe32d49dc08"
-  integrity sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg==
-
 regex-not@^1.0.0, regex-not@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/regex-not/-/regex-not-1.0.2.tgz#1f4ece27e00b0b65e0247a6810e6a85d83a5752c"


### PR DESCRIPTION
Been playing around with the tpl, let me know what you think @learnforpractice 

This might not be a good idea but just wanted to see what was possible

Modifies the action transformer to allow re-use (eliminating the @packer)

Before:
```
@packer
class MyData {
    constructor(
        public name: string
    ){}
}

const actionWrapper = new ActionWrapper("saygoodbye")
const action = actionWrapper.act(this.receiver, new PermissionLevel(this.receiver))
action.send(new MyData('alice'))
```

After
```
const actionWrapper = new ActionWrapper("saygoodbye")
const action = actionWrapper.act(this.receiver, new PermissionLevel(this.receiver))
action.send(new sayGoodbyeAction('alice'))
```

While this brings new simplicity to writing contracts, a downside is that you lose Intellisense on `new MyData` and instead have to rely on compile time checking