### PR TITLE
Multi-index API by value

### DIFF
--- a/as-packages/chain/assembly/singleton.ts
+++ b/as-packages/chain/assembly/singleton.ts
@@ -10,12 +10,7 @@ export class Singleton<T extends MultiIndexValue> {
     }
 
     set(value: T, payer: Name): void {
-        let it = this.mi.find(this.key);
-        if (it.isOk()) {
-            this.mi.update(it, value, payer);
-        } else {
-            this.mi.store(value, payer);
-        }
+        this.mi.set(value, payer)
     }
 
     getOrNull(): T | null {
@@ -38,7 +33,7 @@ export class Singleton<T extends MultiIndexValue> {
     remove(): void {
         let it = this.mi.find(this.key);
         if (it.isOk()) {
-            this.mi.remove(it);
+            this.mi.removeItr(it);
         }
     }
 }

--- a/as-packages/chain/tests/testmi.ts
+++ b/as-packages/chain/tests/testmi.ts
@@ -299,8 +299,15 @@ class MyContract extends Contract{
             check(ret.value.value[0] == 77, "idx256.lowerBound 2: bad secondary value!");
         }
 
+        // Update by value
+        value = new MyData(7, 89, new U128(100), 9.98);
+        mi.update(value, this.receiver);
+        value = mi.get(it);
+        check(value.a == 7 && value.b == 89 && value.c == new U128(100) && value.d == 9.98, "bad value");
+
+        // Update by iterator
         value = new MyData(7, 88, new U128(99), 9.99);
-        mi.update(it, value, this.receiver);
+        mi.updateItr(it, value, this.receiver);
         value = mi.get(it);
         check(value.a == 7 && value.b == 88 && value.c == new U128(99) && value.d == 9.99, "bad value");
 
@@ -308,9 +315,21 @@ class MyContract extends Contract{
         // 4 5 6
         // 7 8 10
         {
-            let it = mi.find(1);
-            mi.remove(it);
+            // Remove by value
+            mi.remove(value);
+            let it = mi.find(7);
+            check(!it.isOk(), "bad iterator!");
+
+            // Remove by iterator
             it = mi.find(1);
+            mi.removeItr(it);
+
+            it = mi.find(1);
+            check(!it.isOk(), "bad iterator!");
+
+            // Remove by value
+            mi.removeEx(4);
+            it = mi.find(4);
             check(!it.isOk(), "bad iterator!");
         }
     }

--- a/examples/allow/allow.contract.ts
+++ b/examples/allow/allow.contract.ts
@@ -93,9 +93,9 @@ export class AllowContract extends Contract {
 
         // Save
         if (!allowedActor.isAllowed && !allowedActor.isBlocked) {
-            this.allowedActorTable.remove(allowedActorItr)
+            this.allowedActorTable.remove(allowedActor)
         } else {
-            this.allowedActorTable.update(allowedActorItr, allowedActor, SAME_PAYER);
+            this.allowedActorTable.update(allowedActor, SAME_PAYER);
         }
     }
 

--- a/examples/balance/balance.contract.ts
+++ b/examples/balance/balance.contract.ts
@@ -143,9 +143,9 @@ export class BalanceContract extends AllowContract {
         // Delete table if no NFTs and no tokens
         // Update table if any NFT or token found
         if (account.nfts.length == 0 && account.tokens.length == 0) {
-            this.accountsTable.remove(accountItr);
+            this.accountsTable.remove(account);
         } else {
-            this.accountsTable.update(accountItr, account, ramPayer);
+            this.accountsTable.update(account, ramPayer);
         }
     }
 }

--- a/examples/counter/counter.ts
+++ b/examples/counter/counter.ts
@@ -45,7 +45,7 @@ class MyContract extends Contract {
         if (it.isOk()) {
             let counter = mi.get(it);
             counter.count += 1;
-            mi.update(it, counter, payer);
+            mi.updateItr(it, counter, payer);
             count = counter.count;
         } else {
             let counter = new Counter(1);

--- a/examples/eosio.token/eosio.token.contract.ts
+++ b/examples/eosio.token/eosio.token.contract.ts
@@ -39,7 +39,7 @@ class TokenContract extends Contract {
         check(quantity.amount <= st.max_supply.amount - st.supply.amount, "quantity exceeds available supply");
 
         st.supply = Asset.add(st.supply, quantity);
-        statstable.update(existing, st, SAME_PAYER);
+        statstable.updateItr(existing, st, SAME_PAYER);
 
         this.addBalance(st.issuer, quantity, st.issuer);
     }
@@ -61,7 +61,7 @@ class TokenContract extends Contract {
         check(quantity.symbol == st.supply.symbol, "symbol precision mismatch");
 
         st.supply = Asset.sub(st.supply, quantity);
-        statstable.update(existing, st, SAME_PAYER);
+        statstable.updateItr(existing, st, SAME_PAYER);
 
         this.subBalance(st.issuer, quantity);
     }
@@ -99,7 +99,7 @@ class TokenContract extends Contract {
         check(account.balance.amount >= value.amount, "overdrawn balance");
 
         account.balance = Asset.sub(account.balance, value);
-        fromAcnts.update(from, account, owner);
+        fromAcnts.updateItr(from, account, owner);
     }
 
     addBalance(owner: Name, value: Asset, ramPayer: Name): void {
@@ -111,7 +111,7 @@ class TokenContract extends Contract {
         } else {
             const account = toAcnts.get(to);
             account.balance = Asset.add(account.balance, value);
-            toAcnts.update(to, account, ramPayer);
+            toAcnts.updateItr(to, account, ramPayer);
         }
     }
 
@@ -141,6 +141,6 @@ class TokenContract extends Contract {
         const it = acnts.requireFind(symbol.code(), "Balance row already deleted or never existed. Action won't have any effect.");
         const account = acnts.get(it);
         check(account.balance.amount == 0, "Cannot close because the balance is not zero.");
-        acnts.remove(it);
+        acnts.removeItr(it);
     }
 }

--- a/examples/escrow/escrow.contract.ts
+++ b/examples/escrow/escrow.contract.ts
@@ -80,7 +80,7 @@ class EscrowContract extends BalanceContract {
         sendLogEscrow(this.receiver, existingEscrow, ESCROW_STATUS.FILL);
 
         // Erase
-        this.escrowsTable.remove(escrowItr);
+        this.escrowsTable.removeItr(escrowItr);
     }
 
     @action(cancelescrow)
@@ -100,7 +100,7 @@ class EscrowContract extends BalanceContract {
         sendLogEscrow(this.receiver, existingEscrow, ESCROW_STATUS.CANCEL);
 
         // Erase
-        this.escrowsTable.remove(escrowItr);
+        this.escrowsTable.removeItr(escrowItr);
     }
 
     @action(logescrow)

--- a/examples/mixinproxy/mixinproxy.ts
+++ b/examples/mixinproxy/mixinproxy.ts
@@ -156,7 +156,7 @@ class MyContract extends Contract{
         if (it.isOk()) {
             let record = db.get(it);
             record.total += asset;
-            db.update(it, record, new Name());
+            db.updateItr(it, record, new Name());
         } else {
             db.store(new TotalFee(asset), this.receiver);
         }
@@ -176,7 +176,7 @@ class MyContract extends Contract{
             let it = db.find(fee.symbol.code());
             let record = new TransferFee(fee);
             if (it.isOk()) {
-                db.update(it, record, new Name());
+                db.updateItr(it, record, new Name());
             } else {
                 db.store(record, this.receiver);
             }
@@ -235,7 +235,7 @@ class MyContract extends Contract{
             if (!it.isOk()) {
                 break;
             }
-            db.remove(it);
+            db.removeItr(it);
             this.incNonce();
             nonce += 1;
         }
@@ -249,7 +249,7 @@ class MyContract extends Contract{
             if (record.nonce > nonce) {
                 break;
             }
-            db.remove(it);
+            db.removeItr(it);
         }
     }
 
@@ -271,7 +271,7 @@ class MyContract extends Contract{
         if (it.isOk()) {
             let item = db.get(it);
             item.count += 1;
-            db.update(it, item, new Name());
+            db.updateItr(it, item, new Name());
         } else {
             let item = new Counter(KEY_NONCE, 2);
             db.store(item, this.receiver);
@@ -426,7 +426,7 @@ class MyContract extends Contract{
             if (it.isOk()) {
                 let item = db.get(it);
                 if (this.handleExpiration(item.event!)) {
-                    db.remove(it);
+                    db.removeItr(it);
                     return;
                 }
             }
@@ -437,7 +437,7 @@ class MyContract extends Contract{
             let it = db.lowerBound(0);
             check(it.isOk(), "error event not found!");
             let record = db.get(it);
-            db.remove(it);
+            db.removeItr(it);
             this.handleEvent(record.event, record.origin_extra);
         }
     }
@@ -450,7 +450,7 @@ class MyContract extends Contract{
         let it = db.find(nonce);
         check (it.isOk(), "pending event not found");
         let record = db.get(it);
-        db.remove(it);
+        db.removeItr(it);
         this.handleEvent(record.event!, origin_extra);
     }
 //action execpending
@@ -459,7 +459,7 @@ class MyContract extends Contract{
 // 	db := NewPendingEventDB(c.self, c.self)
 // 	it, item := db.Get(nonce)
 // 	check(it.IsOk(), "pending event not found")
-// 	db.Remove(it)
+// 	db.removeItr(it)
 // 	check(len(origin_extra) > 0, "origin_extra not not be empty")
 // 	c.HandleEvent(&item.event, origin_extra)
 // }
@@ -634,7 +634,7 @@ class MyContract extends Contract{
         let db = MixinAsset.new(this.receiver, this.receiver);
         let it = db.find(symbol.code());
         check(it.isOk(), "asset does not exists!");
-        db.remove(it);
+        db.removeItr(it);
     }
 
     @action("setaccfee")
@@ -710,7 +710,7 @@ class MyContract extends Contract{
         } else {
             let item = db.get(it);
             item.count += 1;
-            db.update(it, item, new Name());
+            db.updateItr(it, item, new Name());
             return item.count;
         }
     }


### PR DESCRIPTION
I've been thinking about how to make the MultiIndex API more friendly to developers 

My proposal is to abstract away iterators as much as possible, and this PR is the first step for it

This is just a proposal, open to discussing more!

**Proposal:**
Store, update and remove all take value by default, and iterators are moved to updateItr and removeItr

**Design:**
Allows developers to write simpler code like:

```js
const accountName = Name.from("eosio.token")
const account = new Account(accountName, 4)

// Store
accountTable.store(acc, accountName)

// Get
const resolvedAccount = accountTable.getByKey(accountName.N)

// Update
resolvedAccount.balance = 3
accountTable.update(resolvedAccount, SAME_PAYER)

// Delete
accountTable.remove(resolvedAccount)
```

**Limitations**
The easier dev experience comes at the cost of addition `find` calls to fetch iterators

**Further Thoughts:**
I would suggest even renaming `getByKey`->`get` and  `get`->`getByItr`, if you're open to it